### PR TITLE
Authenticate the Web UI tab via header injection instead of URL credentials

### DIFF
--- a/src/bg/Bg.ts
+++ b/src/bg/Bg.ts
@@ -4,6 +4,7 @@ import ContextMenu from './ContextMenu';
 import BgStore, { IBgStore } from '../stores/BgStore';
 import { autorun } from 'mobx';
 import TransmissionClient from './TransmissionClient';
+import updateWebUiAuthRule from './webUiAuthRule';
 import MobxPatchLine from '../tools/MobxPatchLine';
 import { serializeError } from 'serialize-error';
 import type { BgMessage, IBgForDaemon, IBgForContextMenu } from '../types';
@@ -88,6 +89,25 @@ class Bg {
             autorunLogger.error('client', 'updateTorrents error', err);
           });
         }
+      });
+
+      autorun(() => {
+        autorunLogger.info('webUiAuthRule');
+        const config = this.bgStore.config;
+        if (!config) return;
+
+        // Inject HTTP Basic auth into requests to the Transmission server so
+        // the Web UI tab loads authenticated without credentials in the URL.
+        updateWebUiAuthRule({
+          ssl: config.ssl,
+          hostname: config.hostname,
+          port: config.port,
+          authenticationRequired: config.authenticationRequired,
+          login: config.login,
+          password: config.password,
+        }).catch((err) => {
+          autorunLogger.error('webUiAuthRule', err);
+        });
       });
 
       autorun(() => {

--- a/src/bg/webUiAuthRule.ts
+++ b/src/bg/webUiAuthRule.ts
@@ -1,0 +1,84 @@
+import getLogger from '../tools/getLogger';
+
+const logger = getLogger('webUiAuthRule');
+
+// A single dynamic declarativeNetRequest rule injects the HTTP Basic auth
+// header into requests bound for the Transmission server, so the Web UI tab
+// (and the RPC calls it makes) are authenticated without embedding
+// credentials in the opened URL. Browsers don't reliably apply URL-embedded
+// credentials to a page's background requests, which left the Web UI showing
+// an empty torrent list until a manual reload.
+const WEB_UI_AUTH_RULE_ID = 1;
+
+// Every resource the server returns is behind Basic auth: the redirect, the
+// HTML, its assets, and the RPC endpoint — so the header must be added to all
+// request types, not just the document.
+const RESOURCE_TYPES: chrome.declarativeNetRequest.ResourceType[] = [
+  chrome.declarativeNetRequest.ResourceType.MAIN_FRAME,
+  chrome.declarativeNetRequest.ResourceType.SUB_FRAME,
+  chrome.declarativeNetRequest.ResourceType.STYLESHEET,
+  chrome.declarativeNetRequest.ResourceType.SCRIPT,
+  chrome.declarativeNetRequest.ResourceType.IMAGE,
+  chrome.declarativeNetRequest.ResourceType.FONT,
+  chrome.declarativeNetRequest.ResourceType.OBJECT,
+  chrome.declarativeNetRequest.ResourceType.XMLHTTPREQUEST,
+  chrome.declarativeNetRequest.ResourceType.PING,
+  chrome.declarativeNetRequest.ResourceType.MEDIA,
+  chrome.declarativeNetRequest.ResourceType.WEBSOCKET,
+  chrome.declarativeNetRequest.ResourceType.OTHER,
+];
+
+interface WebUiAuthConfig {
+  ssl: boolean;
+  hostname: string;
+  port: number;
+  authenticationRequired: boolean;
+  login: string;
+  password: string;
+}
+
+/**
+ * Keep the Web UI auth header-injection rule in sync with the current config.
+ * Removes the rule when authentication isn't required (or no host is set).
+ */
+export default async function updateWebUiAuthRule(config: WebUiAuthConfig): Promise<void> {
+  const dnr = chrome.declarativeNetRequest;
+  // Guard so a missing permission/old runtime degrades gracefully rather than
+  // throwing inside an autorun.
+  if (!dnr?.updateDynamicRules) return;
+
+  const removeRuleIds = [WEB_UI_AUTH_RULE_ID];
+
+  try {
+    if (!config.authenticationRequired || !config.hostname) {
+      await dnr.updateDynamicRules({ removeRuleIds });
+      return;
+    }
+
+    const scheme = config.ssl ? 'https' : 'http';
+    const rule: chrome.declarativeNetRequest.Rule = {
+      id: WEB_UI_AUTH_RULE_ID,
+      priority: 1,
+      action: {
+        type: chrome.declarativeNetRequest.RuleActionType.MODIFY_HEADERS,
+        requestHeaders: [
+          {
+            header: 'Authorization',
+            operation: chrome.declarativeNetRequest.HeaderOperation.SET,
+            value: 'Basic ' + btoa([config.login, config.password].join(':')),
+          },
+        ],
+      },
+      condition: {
+        // Anchor to the exact scheme://host:port so the header is only sent to
+        // the configured Transmission server.
+        urlFilter: `|${scheme}://${config.hostname}:${config.port}/`,
+        resourceTypes: RESOURCE_TYPES,
+      },
+    };
+
+    await dnr.updateDynamicRules({ removeRuleIds, addRules: [rule] });
+  } catch (err) {
+    logger.error('failed to update Web UI auth rule', err);
+  }
+}

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -18,7 +18,7 @@
         "48": "assets/icons/icon_48.png",
         "128": "assets/icons/icon_128.png"
     },
-    "permissions": ["storage", "notifications", "contextMenus", "scripting", "alarms"],
+    "permissions": ["storage", "notifications", "contextMenus", "scripting", "alarms", "declarativeNetRequestWithHostAccess"],
     "host_permissions": ["http://*/*", "https://*/*"],
     "name": "__MSG_appName__",
     "description": "__MSG_appDesc__",

--- a/src/stores/ConfigStore.ts
+++ b/src/stores/ConfigStore.ts
@@ -329,15 +329,17 @@ const ConfigStore = types
         });
       },
       get webUiUrl(): string {
+        // Credentials are intentionally NOT embedded here. Browsers don't
+        // reliably apply URL-embedded credentials to a page's background
+        // requests, which made the Web UI load with an empty torrent list.
+        // The background injects an Authorization header for this server
+        // instead (see webUiAuthRule).
         const urlObject: url.UrlObject = {
           protocol: self.ssl ? 'https' : 'http',
           port: self.port,
           hostname: self.hostname,
           pathname: self.webPathname,
         };
-        if (self.authenticationRequired) {
-          urlObject.auth = [self.login, self.password].join(':');
-        }
         return url.format(urlObject);
       },
       get activeTorrentColumns() {


### PR DESCRIPTION
## Summary

Closes #18. With **Authentication required** enabled, the **Web UI** button opened the server URL with credentials embedded (`user:pass@host`). Browsers apply those credentials to the top-level navigation but **not** reliably to the page's background RPC (`XMLHttpRequest`) calls, so the Web UI loaded with an **empty torrent list** until a manual reload primed the browser's auth cache.

See #18 for the full root-cause writeup.

## Change

Transmission only supports HTTP Basic auth — every request (the page, its assets, and each `/transmission/rpc` call) must carry an `Authorization` header; there is no session/cookie login. This PR:

- Adds `src/bg/webUiAuthRule.ts` — registers a dynamic `declarativeNetRequest` rule that injects `Authorization: Basic <creds>` into requests to the configured Transmission `scheme://host:port`, using the same credentials/encoding already used for RPC in `TransmissionTransport`.
- Wires it into a `Bg.ts` `autorun`, so the rule stays in sync as host/port/ssl/login/password/auth change (and is removed when auth is off).
- Stops embedding `user:pass@` in `webUiUrl` (`ConfigStore.ts`) — the header injection authenticates both the page and its RPC calls consistently, so the UI loads populated on the first click with no prompt and no credentials in the URL.

## ⚠️ Permission change — please review before merging

This adds the **`declarativeNetRequestWithHostAccess`** permission to the manifest (host access is already granted via the existing `host_permissions`). That means a **Chrome Web Store re-review** on the next publish, and a header-modifying permission may attract extra scrutiny. As discussed in #18, this is the maintainer's call — happy to adjust the approach if the permission cost isn't acceptable. (The only no-new-permission alternative is dropping the embedded credentials and letting the browser show its native Basic-auth prompt on first open — reliable, but a one-time prompt per session instead of silent login.)

### Why a new permission for the "same" header the extension already sets

The RPC header is set on requests the **extension itself** originates via `fetch` — that's plain JS, no permission needed. The Web UI tab's requests are made by **another page and the browser**, which the extension can't modify without the network-interception permission. Same header value, fundamentally different mechanism.

## Testing

- `tsc --noEmit` and `eslint` clean; existing suite passes (155 tests on this branch).
- Manually verified in a local unpacked build against a live, auth-enabled Transmission server: the Web UI now loads the torrent list **populated on the first click**, with no credentials in the URL and no manual reload.

## Note

Independent of and non-conflicting with #17 (magnet-link fix) — different files, either can merge first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)